### PR TITLE
Feat/socket

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -13,6 +13,9 @@
   <div ui-view class="container"></div>
 
   <link rel="stylesheet" type="text/css" href="bower_components/codemirror/lib/codemirror.css">
+
+  <script src="https://cdn.socket.io/socket.io-1.3.5.js"></script>
+
   <script type="text/javascript" src="bower_components/angular/angular.min.js"></script>
   <script type="text/javascript" src="bower_components/angular-ui-router/release/angular-ui-router.js"></script>
   <script type="text/javascript" src="bower_components/codemirror/lib/codemirror.js"></script>
@@ -22,5 +25,8 @@
   <script type="text/javascript" src="game/game.js"></script>
   <script type="text/javascript" src="leaderboard/leaderboard.js"></script>
   <script type="text/javascript" src="leaderboard/setInitials.js"></script>
+  <script>
+    var socket = io();
+  </script>
 </body>
 </html>

--- a/client/index.html
+++ b/client/index.html
@@ -13,9 +13,6 @@
   <div ui-view class="container"></div>
 
   <link rel="stylesheet" type="text/css" href="bower_components/codemirror/lib/codemirror.css">
-
-  <script src="https://cdn.socket.io/socket.io-1.3.5.js"></script>
-
   <script type="text/javascript" src="bower_components/angular/angular.min.js"></script>
   <script type="text/javascript" src="bower_components/angular-ui-router/release/angular-ui-router.js"></script>
   <script type="text/javascript" src="bower_components/codemirror/lib/codemirror.js"></script>
@@ -25,8 +22,5 @@
   <script type="text/javascript" src="game/game.js"></script>
   <script type="text/javascript" src="leaderboard/leaderboard.js"></script>
   <script type="text/javascript" src="leaderboard/setInitials.js"></script>
-  <script>
-    var socket = io();
-  </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
     "morgan": "~1.6.1",
     "protractor-screenshot-reporter": "0.0.5",
     "requirejs": "^2.1.20"
+  },
+  "dependencies": {
+    "socket.io": "^1.3.6"
   }
 }

--- a/server.js
+++ b/server.js
@@ -21,6 +21,20 @@ app.use(bodyParser.json({ type: 'application/vnd.api+json' })); // parse applica
 app.use(methodOverride());
 app.use('/api', api);
 
+// Socket.IO
+var server = require('http').Server(app);
+var io = require('socket.io')(server);
+
+io.on('connection', function(socket) {
+  // unique id for socket looks something like this "lvkiH50mgbBqAG_2AAAC"
+  console.log('a user connected: ', socket.id);
+
+  // disconnect
+  socket.on('disconnect', function() {
+    console.log('user disconnected');
+  });
+});
+
 var port = process.env.PORT || 8080;
-app.listen(port);
+server.listen(port);
 console.log("App listening on port " + port);

--- a/server.js
+++ b/server.js
@@ -29,6 +29,47 @@ io.on('connection', function(socket) {
   // unique id for socket looks something like this "lvkiH50mgbBqAG_2AAAC"
   console.log('a user connected: ', socket.id);
 
+  socket.on('player:ready', function() {
+    // store socket.id and socket somewhere
+    // check if another player is ready & waiting
+      // if so, pair them together, and emit 'game:start' to both
+      socket.emit('game:start');
+      // get opponent socket object, then opponentSocket.emit('game:start');
+  });
+
+  socket.on('player:progress', function(progress) {
+    // store player progress somewhere?
+    // get opponent socket object, opponentSocket
+    // determine if ending conditions are met, if so
+      // socket.emit('game:win'); // or socket.emit('game:lose')
+      // opponentSocket.emit('game:lose') // or opponentSocket.emit('game:win')
+    // if not, just update opponent on player's progress
+      // opponentSocket.emit('opponent:progress', progress)
+  });
+
+  socket.on('player:timeup', function() {
+    // get opponent socket object
+    // if player is ahead
+      // socket.emit('game:wait');
+      // need to store level for comparison when opponent reaches the same level
+    // if player is behind
+      // socket.emit('game:lose');
+      // opponentSocket.emit('game:win');
+  });
+
+  //--- for testing -- delete when ready
+  var fakeOpponentLevel = 1;
+  var fakeOpponentScore = 0;
+  setInterval(function() {
+    socket.emit('opponent:progress', {
+      level: fakeOpponentLevel,
+      score: fakeOpponentScore
+    });
+    fakeOpponentScore += 100;
+    fakeOpponentLevel += 1;
+  }, 5000);
+  //---
+
   // disconnect
   socket.on('disconnect', function() {
     console.log('user disconnected');


### PR DESCRIPTION
### Here are the events emitted from client:
- `player:ready` emitted when client is done loading, and is at waiting screen.
- `player:progress` emitted when client reaches a new level. Both `score` and `level` are sent to server
- `player:timeup` emitted when client is out of time at current level
### TODO: server side event listeners (I have pseudocode):
- server will listen for `player:ready` events and pair the sockets. Once paired, the server will emit `game:start` to both players.
- server will listen for `player:timeup` and if the player is ahead, emit `game:wait` event for player to wait until opponent catches up. If player is behind, then send `game:win` and `game:lose` events.
- server will listen for `player:progress` and emit `opponent:progress` event the opponent. It will also check ending conditions and if they are met, send `game:win` and `game:lose` events.

Connects to #3 
