### PR TITLE
(feat) Implemented server side socket listeners

### DIFF
--- a/server.js
+++ b/server.js
@@ -21,60 +21,8 @@ app.use(bodyParser.json({ type: 'application/vnd.api+json' })); // parse applica
 app.use(methodOverride());
 app.use('/api', api);
 
-// Socket.IO
 var server = require('http').Server(app);
-var io = require('socket.io')(server);
-
-io.on('connection', function(socket) {
-  // unique id for socket looks something like this "lvkiH50mgbBqAG_2AAAC"
-  console.log('a user connected: ', socket.id);
-
-  socket.on('player:ready', function() {
-    // store socket.id and socket somewhere
-    // check if another player is ready & waiting
-      // if so, pair them together, and emit 'game:start' to both
-      socket.emit('game:start');
-      // get opponent socket object, then opponentSocket.emit('game:start');
-  });
-
-  socket.on('player:progress', function(progress) {
-    // store player progress somewhere?
-    // get opponent socket object, opponentSocket
-    // determine if ending conditions are met, if so
-      // socket.emit('game:win'); // or socket.emit('game:lose')
-      // opponentSocket.emit('game:lose') // or opponentSocket.emit('game:win')
-    // if not, just update opponent on player's progress
-      // opponentSocket.emit('opponent:progress', progress)
-  });
-
-  socket.on('player:timeup', function() {
-    // get opponent socket object
-    // if player is ahead
-      // socket.emit('game:wait');
-      // need to store level for comparison when opponent reaches the same level
-    // if player is behind
-      // socket.emit('game:lose');
-      // opponentSocket.emit('game:win');
-  });
-
-  //--- for testing -- delete when ready
-  var fakeOpponentLevel = 1;
-  var fakeOpponentScore = 0;
-  setInterval(function() {
-    socket.emit('opponent:progress', {
-      level: fakeOpponentLevel,
-      score: fakeOpponentScore
-    });
-    fakeOpponentScore += 100;
-    fakeOpponentLevel += 1;
-  }, 5000);
-  //---
-
-  // disconnect
-  socket.on('disconnect', function() {
-    console.log('user disconnected');
-  });
-});
+var io = require('./server/socket')(server);
 
 var port = process.env.PORT || 8080;
 server.listen(port);

--- a/server/socket.js
+++ b/server/socket.js
@@ -1,0 +1,124 @@
+// ----- helpers
+var challenger = null;
+var players = {}; // hash of key = socket.id, value = { socket, score, level, timeup }
+var room = 0;
+
+var getOpponentSocket = function(socket) {
+  var room = socket.rooms[1];
+  if( room === undefined ) return; // if no room, then no match is going on
+
+  var opponent;
+  // this is an array of all clients in the room
+  Object.keys(io.nsps['/'].adapter.rooms[room]).forEach(function(id) {
+    if( socket.id !== id ) {
+      opponent = players[id].socket;
+    }
+  });
+  return opponent;
+}
+
+var endGame = function(socket, win) {
+  var opponent = getOpponentSocket(socket);
+  if( !opponent ) return;
+
+  socket.emit('game:'+ (win ? 'win' : 'lose'));
+  opponent.emit('game:'+ (win ? 'lose' : 'win'));
+  delete players[opponent.id];
+  delete players[socket.id];
+}
+
+module.exports = function(server) {
+  var io = require('socket.io')(server);
+
+  io.on('connection', function(socket) {
+    // unique id for socket looks something like this "lvkiH50mgbBqAG_2AAAC"
+    console.log('a user connected: ', socket.id);
+
+    // client is ready to enter a match
+    socket.on('player:ready', function() {
+      players[socket.id] = {
+        socket: socket,
+        score: 0,
+        level: 0,
+        timeup: false
+      };
+
+      if( challenger ) {
+        socket.join(room);
+        challenger.join(room);
+        io.to(room).emit('game:start');
+
+        room += 1;
+        challenger = null;
+      } else {
+        challenger = socket;
+      }
+    });
+
+    // client periodic update on level/score
+    socket.on('player:progress', function(progress) {
+      var player = players[socket.id];
+      player.level = progress.level;
+      player.score = progress.score;
+      var opponent = players[getOpponentSocket(socket).id];
+
+      // if opponent time up and player is ahead of opponent
+      if( opponent.timeup && player.level >= opponent.level ) {
+        return endGame(socket, true); // player wins
+      }
+      opponent.socket.emit('opponent:progress', progress);
+    });
+
+    // player is done with all levels
+    socket.on('player:done', function() {
+      endGame(socket, true); // first to finish wins
+    });
+
+    // player ran out of time
+    socket.on('player:timeup', function() {
+      var player = players[socket.id];
+      player.timeup = true;
+      var opponent = players[getOpponentSocket(socket).id];
+
+      // if on the same level as opponent and opponent also timeup
+      if( player.level === opponent.level && opponent.timeup ) {
+        return endGame(socket, player.score > opponent.score); // higher score is winner
+      }
+
+      // if ahead of opponent
+      if( player.level >= opponent.level ) {
+        return socket.emit('game:wait'); // wait
+      }
+
+      // if behind opponent
+      if( player.level < opponent.level ) {
+        return endGame(socket, false); // player loses
+      }
+    });
+
+    // disconnect
+    socket.on('disconnect', function() {
+      if( challenger === socket ) {
+        challenger = null;
+      }
+      endGame(socket, false); // end the game if there is one, opponent wins
+      console.log('user disconnected');
+    });
+
+    //--- for testing -- delete when ready
+    var fakeOpponentLevel = 1;
+    var fakeOpponentScore = 0;
+    setInterval(function() {
+      socket.emit('opponent:progress', {
+        level: fakeOpponentLevel,
+        score: fakeOpponentScore
+      });
+      fakeOpponentScore += 100;
+      fakeOpponentLevel += 1;
+    }, 5000);
+    //---
+  });
+
+  return io;
+}
+


### PR DESCRIPTION
I refactored the socket stuff into a `socket.js` file.

Here's the overall flow:
1. Player A opens speedcoder, when everything is done loading, an event `player:ready` is emitted to server
2. Server stores player in a `challenger` variable
3. Player B opens speedcoder, and similarly emits event `player:ready`
4. Server checks that there is a `challenger` ready, pairs players A and B, and emits `game:start` to both
5. Player A and B will emit `player:progress` events to server at each level, and server will emit `opponent:progress` events to the corresponding player so they can update UI accordingly

Ending conditions (same thing applies to player B):
- Player A complete all batches first, will emit `player:done` and will win the game
- If player A runs out of time, they will emit `player:timeup` and then several scenarios can occur:
  - If player A was behind in level, player A immediately loses
  - If player A is ahead in level, they are told to wait via `game:wait`
    - Once player B gets ahead of A in level, player B wins
    - If player B runs out of time on the same level, the scores are compared for winner (though A always wins in this case since he was faster)
    - If player B runs out of time and is behind in level, player B loses

Let me know if I missed anything.

Closes #3 
