### PR TITLE
(feat) Add client socket listeners & emitters

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,7 @@
     "angular": "~1.4.3",
     "angular-ui-router": "~0.2.15",
     "angular-mocks": "~1.4.3",
-    "angular-ui-codemirror": "~0.3.0"
+    "angular-ui-codemirror": "~0.3.0",
+    "socket.io-client": "~1.3.6"
   }
 }

--- a/client/app.js
+++ b/client/app.js
@@ -1,4 +1,4 @@
-angular.module('app', ['ui.router', 'app.game', 'app.leaderboard', 'app.setInitials', 'ui.codemirror'])
+angular.module('app', ['ui.router', 'app.game', 'app.leaderboard', 'app.setInitials', 'app.socket', 'ui.codemirror'])
 
 .config(['$stateProvider', '$urlRouterProvider', function($stateProvider, $urlRouterProvider){
 

--- a/client/index.html
+++ b/client/index.html
@@ -18,9 +18,11 @@
   <script type="text/javascript" src="bower_components/codemirror/lib/codemirror.js"></script>
   <script type="text/javascript" src="bower_components/angular-ui-codemirror/ui-codemirror.js"></script>
   <script type="text/javascript" src="bower_components/codemirror/mode/javascript/javascript.js"></script>
+  <script type="text/javascript" src="bower_components/socket.io-client/socket.io.js"></script>
   <script type="text/javascript" src="app.js"></script>
   <script type="text/javascript" src="game/game.js"></script>
   <script type="text/javascript" src="leaderboard/leaderboard.js"></script>
   <script type="text/javascript" src="leaderboard/setInitials.js"></script>
+  <script type="text/javascript" src="socket/socket.js"></script>
 </body>
 </html>

--- a/client/socket/socket.js
+++ b/client/socket/socket.js
@@ -1,0 +1,26 @@
+angular.module('app.socket', [])
+
+.factory('Socket', function($rootScope) {
+  var socket = new io.connect();
+
+  return {
+    on: function (eventName, callback) {
+      socket.on(eventName, function () {
+        var args = arguments;
+        $rootScope.$apply(function () {
+            callback.apply(socket, args);
+        });
+      });
+    },
+    emit: function (eventName, data, callback) {
+      socket.emit(eventName, data, function () {
+        var args = arguments;
+        $rootScope.$apply(function () {
+            if (callback) {
+                callback.apply(socket, args);
+            }
+        });
+      });
+    }
+  }
+})


### PR DESCRIPTION
- Added Socket.io client library
- Created Socket service with `.on` (to set listeners) and `.emit` (to send event/data to server)
- Added listeners to socket. Implemented ones are `game:start`, which kicks off the game, and `opponent:progress`, which updates scope variable to track opponent data.
- Emit `player:ready` event on load, and `player:progress` when player reaches new level
- Refactored game setup data into `startGame` function

Closes #4 
