### PR TITLE
(feat) Add waiting and communicate player's position [Connects #18]

### DIFF
--- a/client/game/game.html
+++ b/client/game/game.html
@@ -1,28 +1,31 @@
 <div ng-controller="gameController">
-  <header class="game-header">
+  <div class="waiting" ng-if="!playing">
+    <p>Waiting...</p>
+  </div>
+  <div class="gameOver" ng-if="gameOver"><p>GAME OVER</p></div>
+  <div class="gameWon" ng-if="gameWon"><p>YOU WIN</p></div>
+  <div class="playing" ng-if="playing">
+    <header class="game-header">
+      <div>
+        <p>Current Level</p>
+        <p class='number'>{{ level }}</p>
+      </div>
+      <div>
+        <p>Total Score</p>
+        <p class='number'>{{ score }}</p>
+      </div>
+      <div>
+        <p>Time Left</p>
+        <p class='number'>{{ timeLimit }}</p>
+      </div>
+    </header>
     <div>
-      <p>Current Level</p>
-      <p class='number'>{{ level }}</p>
+      <p id="gameContent" class="noselect">{{ challenge }}</p>
+      <form>
+        <textarea ui-codemirror="{onLoad: codemirrorLoaded}" ui-codemirror-opts="editorOptions"
+          cols="60" rows="10" ng-disabled="gameOver"></textarea>
+        <span ng-if="showMessage">{{ submitMessage }}</span>
+      </form>
     </div>
-    <div>
-      <p>Total Score</p>
-      <p class='number'>{{ score }}</p>
-    </div>
-    <div>
-      <p>Time Left</p>
-      <p class='number'>{{ timeLimit }}</p>
-    </div>
-  </header>
-
-  <div>
-    <div class="gameOver" ng-if="gameOver"><p>GAME OVER</p></div>
-    <div class="gameWon" ng-if="gameWon"><p>YOU WIN</p></div>
-
-    <p id="gameContent" class="noselect">{{ challenge }}</p>
-    <form>
-      <textarea ui-codemirror="{onLoad: codemirrorLoaded}" ui-codemirror-opts="editorOptions"
-        cols="60" rows="10" ng-disabled="gameOver"></textarea>
-      <span ng-if="showMessage">{{ submitMessage }}</span>
-    </form>
   </div>
 </div>

--- a/package.json
+++ b/package.json
@@ -37,9 +37,7 @@
     "mongoose": "^4.1.1",
     "morgan": "~1.6.1",
     "protractor-screenshot-reporter": "0.0.5",
-    "requirejs": "^2.1.20"
-  },
-  "dependencies": {
+    "requirejs": "^2.1.20",
     "socket.io": "^1.3.6"
   }
 }

--- a/server/socket.js
+++ b/server/socket.js
@@ -1,34 +1,35 @@
-// ----- helpers
 var challenger = null;
 var players = {}; // hash of key = socket.id, value = { socket, score, level, timeup }
 var room = 0;
 
-var getOpponentSocket = function(socket) {
-  var room = socket.rooms[1];
-  if( room === undefined ) return; // if no room, then no match is going on
-
-  var opponent;
-  // this is an array of all clients in the room
-  Object.keys(io.nsps['/'].adapter.rooms[room]).forEach(function(id) {
-    if( socket.id !== id ) {
-      opponent = players[id].socket;
-    }
-  });
-  return opponent;
-}
-
-var endGame = function(socket, win) {
-  var opponent = getOpponentSocket(socket);
-  if( !opponent ) return;
-
-  socket.emit('game:'+ (win ? 'win' : 'lose'));
-  opponent.emit('game:'+ (win ? 'lose' : 'win'));
-  delete players[opponent.id];
-  delete players[socket.id];
-}
 
 module.exports = function(server) {
   var io = require('socket.io')(server);
+
+  // ----- helpers
+  var getOpponentSocket = function(socket) {
+    var room = socket.rooms[1];
+    if( room === undefined ) return; // if no room, then no match is going on
+
+    var opponent;
+    // this is an array of all clients in the room
+    Object.keys(io.nsps['/'].adapter.rooms[room]).forEach(function(id) {
+      if( socket.id !== id ) {
+        opponent = players[id].socket;
+      }
+    });
+    return opponent;
+  }
+
+  var endGame = function(socket, win) {
+    var opponent = getOpponentSocket(socket);
+    if( !opponent ) return;
+
+    socket.emit('game:'+ (win ? 'win' : 'lose'));
+    opponent.emit('game:'+ (win ? 'lose' : 'win'));
+    delete players[opponent.id];
+    delete players[socket.id];
+  }
 
   io.on('connection', function(socket) {
     // unique id for socket looks something like this "lvkiH50mgbBqAG_2AAAC"
@@ -61,6 +62,7 @@ module.exports = function(server) {
       player.level = progress.level;
       player.score = progress.score;
       var opponent = players[getOpponentSocket(socket).id];
+      console.log('player:progress received');
 
       // if opponent time up and player is ahead of opponent
       if( opponent.timeup && player.level >= opponent.level ) {
@@ -106,6 +108,7 @@ module.exports = function(server) {
     });
 
     //--- for testing -- delete when ready
+    /*
     var fakeOpponentLevel = 1;
     var fakeOpponentScore = 0;
     setInterval(function() {
@@ -116,6 +119,7 @@ module.exports = function(server) {
       fakeOpponentScore += 100;
       fakeOpponentLevel += 1;
     }, 5000);
+    */
     //---
   });
 


### PR DESCRIPTION
## Events
- We are now emitting `player:gameComplete` when `loadBatch` doesn't return anything. This puts responsibility on the client for ending the game. 
- When the event `player:progress` is emitted during a level, the players position is now sent along with level and score.
- When the event `player:progress` is emitted at the end of a level, `levelComplete` property is added to data. 

From the server's perspective, what properties do we need on these events? We added more than likely necessary to cover as much ground as possible.
## Server
- Moved helper functions into exported module to handle errors relating to `io` being undefined.
- Commented out test opponent
## Game View
- Restructured HTML to hide game-related components while waiting (both before connecting to an opponent and after finishing level before opponent).
